### PR TITLE
More rust example improvements

### DIFF
--- a/example/rust/README.md
+++ b/example/rust/README.md
@@ -20,7 +20,16 @@ The example projects use cargo, so there are two ways to build the project:
     `cargo build --target wasm32-unknown-unknown --release`
 
 ## Deploy using wasme
-Once you build the .wasm file you can publish it to the Hub using wasme. Navigate to the `rust/target/wasm32-unknown-unknown/release` directory and run:
+Now that the build is ready you need to package it into an OCI image. First, navigate to
+the `rust/target/wasm32-unknown-unknown/release` directory.
+
+You need to tell `wasme` some details about your filter. Change the `config.json` file
+to reflect your filters details. Most importantly you want to change the filter `rootId` field.
+
+Now you need to actually generate the image. You can do so with `wasme` by running:
+`wasme build precompiled target/wasm32-unknown-unknown/release/wasm_filter_bindings.wasm --tag webassemblyhub.io/<github username>/<filter-name>:v0.5 --config config-13.json`
+
+Once the image is built you can publish it to the Hub using `wasme`. Run:
 `wasme push webassemblyhub.io/<github username>/<filter-name>:v0.1 ./wasm_filter_bindings.wasm`
 
 ## More about wasme

--- a/example/rust/config.json
+++ b/example/rust/config.json
@@ -1,0 +1,12 @@
+{
+    "type": "envoy_proxy",
+    "abiVersions": [
+      "v0-541b2c1155fffb15ccde92b8324f3e38f7339ba6",
+      "v0-097b7f2e4cc1fb490cc1943d0d633655ac3c522f"
+    ],
+    "config": {
+      "rootIds": [
+        "my-filter"
+      ]
+    }
+  }

--- a/example/rust/src/host.rs
+++ b/example/rust/src/host.rs
@@ -1,4 +1,4 @@
-use std::os::raw::c_char;
+use std::os::raw::{c_char, c_void};
 
 extern "C" {
     pub fn proxy_get_configuration(
@@ -6,11 +6,15 @@ extern "C" {
         message_size: *mut usize,
     ) -> WasmResult;
 
-    pub fn proxy_log(level: u32, message_data: *const u8, message_size: usize) -> WasmResult;
+    pub fn proxy_log(
+        level: LogLevel,
+        logMessage: *const u8,
+        messageSize: usize,
+    ) -> WasmResult;
 
-    // header values
+    // Headers
     pub fn proxy_add_header_map_value(
-        hm_type: HeaderMapType,
+        type_: HeaderMapType,
         key_ptr: *const c_char,
         key_size: usize,
         value_ptr: *const c_char,
@@ -18,55 +22,222 @@ extern "C" {
     ) -> WasmResult;
 
     pub fn proxy_get_header_map_value(
-        hm_type: HeaderMapType,
+        type_: HeaderMapType,
         key_ptr: *const c_char,
         key_size: usize,
-        value_ptr: *const c_char,
+        value_ptr: *mut *const c_char,
         value_size: *mut usize,
     ) -> WasmResult;
 
-    pub fn proxy_set_header_map_pairs(
-        hm_type: HeaderMapType,
-        ptr: *const c_char,
-        size: usize,
+    pub fn proxy_get_header_map_pairs(
+        type_: HeaderMapType,
+        ptr: *mut *const c_char,
+        size: *mut usize,
     ) -> WasmResult;
 
-    pub fn proxy_get_header_map_pairs(
-        hm_type: HeaderMapType,
+    pub fn proxy_set_header_map_pairs(
+        type_: HeaderMapType,
         ptr: *const c_char,
         size: usize,
     ) -> WasmResult;
 
     pub fn proxy_replace_header_map_value(
-        hm_type: HeaderMapType,
+        type_: HeaderMapType,
         key_ptr: *const c_char,
-        size: usize,
+        key_size: usize,
         value_ptr: *const c_char,
         value_size: usize,
     ) -> WasmResult;
 
     pub fn proxy_remove_header_map_value(
-        hm_type: HeaderMapType,
+        type_: HeaderMapType,
         key_ptr: *const c_char,
         key_size: usize,
     ) -> WasmResult;
 
-    pub fn proxy_get_header_map_size(hm_type: HeaderMapType, size: *mut usize) -> WasmResult;
+    pub fn proxy_get_header_map_size(type_: HeaderMapType, size: *mut usize) -> WasmResult;
 
     //buffer values
     pub fn proxy_get_buffer_bytes(
-        buff_type: BufferType,
+        type_: BufferType,
         start: u32,
-        lengthL: u32,
-        ptr: *const c_char,
+        length: u32,
+        ptr: *mut *const c_char,
         size: *mut usize,
     ) -> WasmResult;
 
     pub fn proxy_get_buffer_status(
-        buff_type: BufferType,
+        type_: BufferType,
         length_ptr: *mut usize,
         flags_ptr: *mut u32,
     ) -> WasmResult;
+
+    //HTTP
+    pub fn proxy_http_call(
+        uri_ptr: *const c_char,
+        uri_size: usize,
+        header_pairs_ptr: *mut c_void,
+        header_pairs_size: usize,
+        body_ptr: *const c_char,
+        body_size: usize,
+        trailer_pairs_ptr: *mut c_void,
+        trailer_pairs_size: usize,
+        timeout_milliseconds: u32,
+        token_ptr: *mut u32,
+    ) -> WasmResult;
+
+    // gRPC
+    pub fn proxy_grpc_call(
+        service_ptr: *const c_char,
+        service_size: usize,
+        service_name_ptr: *const c_char,
+        service_name_size: usize,
+        method_name_ptr: *const c_char,
+        method_name_size: usize,
+        request_ptr: *const c_char,
+        request_size: usize,
+        timeout_milliseconds: u32,
+        token_ptr: *mut u32,
+    ) -> WasmResult;
+
+    pub fn proxy_grpc_stream(
+        service_ptr: *const c_char,
+        service_size: usize,
+        service_name_ptr: *const c_char,
+        service_name_size: usize,
+        method_name_ptr: *const c_char,
+        method_name_size: usize,
+        token_ptr: *mut u32,
+    ) -> WasmResult;
+
+    pub fn proxy_grpc_cancel(token: u32) -> WasmResult;
+
+    pub fn proxy_grpc_close(token: u32) -> WasmResult;
+
+    pub fn proxy_grpc_send(
+        token: u32,
+        message_ptr: *const c_char,
+        message_size: usize,
+        end_stream: u32,
+    ) -> WasmResult;
+
+    // Metrics
+    pub fn proxy_define_metric(
+        type_: MetricType,
+        name_ptr: *const c_char,
+        name_size: usize,
+        metric_id: *mut u32,
+    ) -> WasmResult;
+
+    pub fn proxy_increment_metric(metric_id: u32, offset: i64) -> WasmResult;
+
+    pub fn proxy_record_metric(metric_id: u32, value: u64) -> WasmResult;
+
+    pub fn proxy_get_metric(metric_id: u32, result: *mut u64) -> WasmResult;
+
+    // Results status details for any previous ABI call and onGrpcClose.
+    pub fn proxy_get_status(
+        status_code_ptr: *mut u32,
+        message_ptr: *mut *const c_char,
+        message_size: *mut usize,
+    ) -> WasmResult;
+
+    // Timer (must be called from a root context, e.g. onStart, onTick).
+    pub fn proxy_set_tick_period_milliseconds(millisecond: u32) -> WasmResult;
+
+    // Time
+    pub fn proxy_get_current_time_nanoseconds(nanoseconds: *mut u64) -> WasmResult;
+
+    // State accessors
+    pub fn proxy_get_property(
+        path_ptr: *const c_char,
+        path_size: usize,
+        value_ptr_ptr: *mut *const c_char,
+        value_size_ptr: *mut usize,
+    ) -> WasmResult;
+
+    pub fn proxy_set_property(
+        path_ptr: *const c_char,
+        path_size: usize,
+        value_ptr: *const c_char,
+        value_size: usize,
+    ) -> WasmResult;
+
+    // Continue/Reply/Route
+    pub fn proxy_continue_request() -> WasmResult;
+
+    pub fn proxy_continue_response() -> WasmResult;
+
+    pub fn proxy_send_local_response(
+        response_code: u32,
+        response_code_details_ptr: *const c_char,
+        response_code_details_size: usize,
+        body_ptr: *const c_char,
+        body_size: usize,
+        additional_response_header_pairs_ptr: *const c_char,
+        additional_response_header_pairs_size: usize,
+        grpc_status: u32,
+    ) -> WasmResult;
+
+    pub fn proxy_clear_route_cache() -> WasmResult;
+
+    // SharedData
+    // Returns: Ok, NotFound
+    pub fn proxy_get_shared_data(
+        key_ptr: *const c_char,
+        key_size: usize,
+        value_ptr: *mut *const c_char,
+        value_size: *mut usize,
+        cas: *mut u32,
+    ) -> WasmResult;
+
+    //  If cas != 0 and cas != the current cas for 'key' return false, otherwise set the value and
+    //  return true.
+    // Returns: Ok, CasMismatch
+    pub fn proxy_set_shared_data(
+        key_ptr: *const c_char,
+        key_size: usize,
+        value_ptr: *const c_char,
+        value_size: usize,
+        cas: u32,
+    ) -> WasmResult;
+
+    // SharedQueue
+    // Note: Registering the same queue_name will overwrite the old registration while preseving any
+    // pending data. Consequently it should typically be followed by a call to
+    // proxy_dequeue_shared_queue. Returns: Ok
+    pub fn proxy_register_shared_queue(
+        queue_name_ptr: *const c_char,
+        queue_name_size: usize,
+        token: *mut u32,
+    ) -> WasmResult;
+
+    // Returns: Ok, NotFound
+    pub fn proxy_resolve_shared_queue(
+        vm_id: *const c_char,
+        vm_id_size: usize,
+        queue_name_ptr: *const c_char,
+        queue_name_size: usize,
+        token: *mut u32,
+    ) -> WasmResult;
+
+    // Returns Ok, Empty, NotFound (token not registered).
+    pub fn proxy_dequeue_shared_queue(
+        token: u32,
+        data_ptr: *mut *const c_char,
+        data_size: *mut usize,
+    ) -> WasmResult;
+
+    // Returns false if the queue was not found and the data was not enqueued.
+    pub fn proxy_enqueue_shared_queue(
+        token: u32,
+        data_ptr: *const c_char,
+        data_size: usize,
+    ) -> WasmResult;
+
+    // System -- ??? No clue what these actually are for
+    pub fn proxy_set_effective_context(effective_context_id: u32) -> WasmResult;
+    pub fn proxy_done() -> WasmResult;
 }
 
 #[repr(C)]
@@ -117,4 +288,21 @@ pub enum WasmResult {
     InternalFailure = 10,
     // The connection/stream/pipe was broken/closed unexpectedly.
     BrokenConnection = 11,
+}
+
+#[repr(C)]
+pub enum LogLevel {
+    Trace = 0,
+    Debug = 1,
+    Info = 2,
+    Warn = 3,
+    Error = 4,
+    Critical = 5
+}
+
+#[repr(C)]
+pub enum MetricType {
+    Counter = 0,
+    Gauge = 1,
+    Histogram = 2
 }

--- a/example/rust/src/lib.rs
+++ b/example/rust/src/lib.rs
@@ -1,6 +1,8 @@
 
 use log::{info, debug};
 use std::collections::HashMap;
+use std::ffi::CString;
+use std::os::raw::{c_char};
 // use serde::de;
 
 mod filter;
@@ -19,13 +21,13 @@ impl Logger {
         log::set_logger(&LOGGER).map(|()| log::set_max_level(log::LevelFilter::Trace))
     }
 
-    fn proxywasm_loglevel(level: log::Level) -> u32 {
+    fn proxywasm_loglevel(level: log::Level) -> host::LogLevel {
         match level {
-            log::Level::Trace => 0,
-            log::Level::Debug => 1,
-            log::Level::Info => 2,
-            log::Level::Warn => 3,
-            log::Level::Error => 4,
+            log::Level::Trace => host::LogLevel::Trace,
+            log::Level::Debug => host::LogLevel::Debug,
+            log::Level::Info => host::LogLevel::Info,
+            log::Level::Warn => host::LogLevel::Warn,
+            log::Level::Error => host::LogLevel::Error,
         }
     }
 }
@@ -300,6 +302,9 @@ fn proxy_on_queue_ready(root_context_id: u32, token: u32) {
 #[no_mangle]
 fn proxy_on_create(context_id: u32, root_context_id: u32) {}
 #[no_mangle]
+pub fn proxy_on_context_create(context_id: u32, parent_context_id: u32) {}
+
+#[no_mangle]
 fn proxy_on_new_connection(context_id: u32) -> FilterStatus {FilterStatus::Continue}
 /// stream decoder
 #[no_mangle]
@@ -330,12 +335,33 @@ fn proxy_on_response_body(context_id: u32, body_buffer_length: u32, end_of_strea
 #[no_mangle]
 fn proxy_on_response_trailers(context_id: u32, trailers: u32) -> FilterTrailersStatus {FilterTrailersStatus::Continue}
 
+pub fn proxy_on_http_call_response(
+    context_id: u32,
+    token: u32,
+    headers: u32,
+    body_size: u32,
+    trailers: u32,
+) {}
 
+// gRPC
+#[no_mangle]
+pub fn proxy_on_grpc_create_initial_metadata(context_id: u32, token: u32, headers: u32) {}
+#[no_mangle]
+pub fn proxy_on_grpc_receive_initial_metadata(context_id: u32, token: u32, headers: u32) {}
+#[no_mangle]
+pub fn proxy_on_grpc_trailing_metadata(context_id: u32, token: u32, trailers: u32) {}
+#[no_mangle]
+pub fn proxy_on_grpc_receive(context_id: u32, token: u32, response_size: u32) {}
+#[no_mangle]
+pub fn proxy_on_grpc_close(context_id: u32, token: u32, status_code: u32) {}
+
+// The stream/vm has completed.
 #[no_mangle]
 fn proxy_on_done(context_id: u32) -> u32 {1}
+// proxy_on_log occurs after proxy_on_done.
 #[no_mangle]
 fn proxy_on_log(context_id: u32) {}
+// The Context in the proxy has been destroyed and no further calls will be coming.
 #[no_mangle]
 fn proxy_on_delete(context_id: u32)  {}
-
 


### PR DESCRIPTION
I've made some improvements to the example documentation, as well as provided an example of adding/replacing headers in an http response. I also generated more of the bindings from the cpp envoy wasm abi using bindgen. I think this may also have corrected some inaccuracies with types in function signatures but i haven't tested all the functions.