### PR TITLE
Add flag to wasme deploy to allow ignoring ABI version check

### DIFF
--- a/tools/wasme/changelog/v0.0.27/ignore-version-check.yaml
+++ b/tools/wasme/changelog/v0.0.27/ignore-version-check.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NEW_FEATURE
+    description: Adds a --ignore-version-check flag to allow using wasme to deploy an image to an unsupported platform/version combo.
+    issueLink: https://github.com/solo-io/wasm/issues/68

--- a/tools/wasme/cli/pkg/cmd/deploy/options.go
+++ b/tools/wasme/cli/pkg/cmd/deploy/options.go
@@ -81,9 +81,10 @@ func (opts *glooOpts) addToFlags(flags *pflag.FlagSet) {
 }
 
 type istioOpts struct {
-	workload       istio.Workload
-	istioNamespace string
-	cacheTimeout   time.Duration
+	workload           istio.Workload
+	istioNamespace     string
+	cacheTimeout       time.Duration
+	ignoreVersionCheck bool
 
 	puller pull.ImagePuller // set by load
 }
@@ -94,6 +95,7 @@ func (opts *istioOpts) addToFlags(flags *pflag.FlagSet) {
 	flags.StringVarP(&opts.workload.Kind, "workload-type", "t", istio.WorkloadTypeDeployment, "type of workload into which the filter should be injected. possible values are "+istio.WorkloadTypeDeployment+" or "+istio.WorkloadTypeDaemonSet)
 	flags.StringVarP(&opts.istioNamespace, "istio-namespace", "", "istio-system", "the namespace where the Istio control plane is installed")
 	flags.DurationVar(&opts.cacheTimeout, "cache-timeout", time.Minute, "the length of time to wait for the server-side filter cache to pull the filter image before giving up with an error. set to 0 to skip the check entirely (note, this may produce a known race condition).")
+	flags.BoolVar(&opts.ignoreVersionCheck, "ignore-version-check", false, "set to disable abi version compatability check.")
 }
 
 type cacheOpts struct {
@@ -200,6 +202,7 @@ func (opts *options) makeProvider(ctx context.Context) (deploy.Provider, error) 
 			nil, // no callback when using CLI
 			opts.istioOpts.istioNamespace,
 			opts.istioOpts.cacheTimeout,
+			opts.istioOpts.ignoreVersionCheck,
 		)
 	}
 

--- a/tools/wasme/cli/pkg/deploy/istio/istio_provider_test.go
+++ b/tools/wasme/cli/pkg/deploy/istio/istio_provider_test.go
@@ -265,6 +265,9 @@ var _ = Describe("IstioProvider", func() {
 			Cache:              cache,
 			IngoreVersionCheck: true,
 		}
+
+		client.EXPECT().Ensure(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
 		glooImage := consts.HubDomain + "/ilackarms/gloo-test:1.3.3-0"
 		err := p.ApplyFilter(&wasmev1.FilterSpec{
 			Id:     "incompatible-filter",

--- a/tools/wasme/cli/pkg/deploy/istio/istio_provider_test.go
+++ b/tools/wasme/cli/pkg/deploy/istio/istio_provider_test.go
@@ -279,6 +279,7 @@ var _ = Describe("IstioProvider", func() {
 
 		// Since this filter won't actually work (it's not compatible),
 		// we need to remove it again so we're not messing up the cluster
+		client.EXPECT().Delete(gomock.Any(), gomock.Any()).Times(1)
 		p.RemoveFilter(incompatibleFilter)
 
 		err = p.ApplyFilter(&wasmev1.FilterSpec{

--- a/tools/wasme/cli/pkg/deploy/istio/istio_provider_test.go
+++ b/tools/wasme/cli/pkg/deploy/istio/istio_provider_test.go
@@ -269,12 +269,17 @@ var _ = Describe("IstioProvider", func() {
 		client.EXPECT().Ensure(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
 		glooImage := consts.HubDomain + "/ilackarms/gloo-test:1.3.3-0"
-		err := p.ApplyFilter(&wasmev1.FilterSpec{
+		incompatibleFilter := &wasmev1.FilterSpec{
 			Id:     "incompatible-filter",
 			Image:  glooImage,
 			Config: nil,
-		})
+		}
+		err := p.ApplyFilter(incompatibleFilter)
 		Expect(err).NotTo(HaveOccurred())
+
+		// Since this filter won't actually work (it's not compatible),
+		// we need to remove it again so we're not messing up the cluster
+		p.RemoveFilter(incompatibleFilter)
 
 		err = p.ApplyFilter(&wasmev1.FilterSpec{
 			Id:     "compatible-filter",

--- a/tools/wasme/cli/pkg/deploy/istio/istio_provider_test.go
+++ b/tools/wasme/cli/pkg/deploy/istio/istio_provider_test.go
@@ -116,6 +116,7 @@ var _ = Describe("IstioProvider", func() {
 			},
 			"",
 			0,
+			false,
 		)
 		Expect(err).NotTo(HaveOccurred())
 

--- a/tools/wasme/cli/pkg/operator/operator.go
+++ b/tools/wasme/cli/pkg/operator/operator.go
@@ -202,6 +202,7 @@ func (f *filterDeploymentHandler) makeProvider(obj *v1.FilterDeployment, puller 
 			onWorkload,
 			dep.Istio.IstioNamespace,
 			f.cacheTimeout,
+			false,
 		)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
New flag is `--ignore-version-check`, should help with filter development against new versions of Istio & Gloo.

Implements https://github.com/solo-io/wasm/issues/68