### PR TITLE
Add ABI verison for Istio 1.5/1.6

### DIFF
--- a/tools/wasme/cli/example/rust-istio-1.7/runtime-config.json
+++ b/tools/wasme/cli/example/rust-istio-1.7/runtime-config.json
@@ -1,6 +1,6 @@
 {
   "type": "envoy_proxy",
-  "abiVersions": ["v0-4689a30309abf31aee9ae36e73d34b1bb182685f"],
+  "abiVersions": ["v0-097b7f2e4cc1fb490cc1943d0d633655ac3c522f", "v0-4689a30309abf31aee9ae36e73d34b1bb182685f"],
   "config": {
     "rootIds": [
       "root_id"


### PR DESCRIPTION
Lets `wasme deploy` deploy the rust filter to Istio 1.5/1.6. Currently the filter works, but the `runtime-config.json` doesn't list that version as compatible.