### PR TITLE
Fix Istio 1.7 / Assemblyscript

### DIFF
--- a/tools/wasme/changelog/v0.0.30/istio-as-1-7.yaml
+++ b/tools/wasme/changelog/v0.0.30/istio-as-1-7.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Fix bug with AssemblyScript filters not being generated with metadata marking them as compatible with Istio 1.7
+    issueLink: https://github.com/solo-io/wasm/issues/216

--- a/tools/wasme/cli/example/assemblyscript/runtime-config.json
+++ b/tools/wasme/cli/example/assemblyscript/runtime-config.json
@@ -3,6 +3,7 @@
   "abiVersions": [
     "v0-541b2c1155fffb15ccde92b8324f3e38f7339ba6",
     "v0-097b7f2e4cc1fb490cc1943d0d633655ac3c522f",
+    "v0-4689a30309abf31aee9ae36e73d34b1bb182685f",
     "v0.2.1"
   ],
   "config": {


### PR DESCRIPTION
In wasme v0.0.29, create an assemblyscript filter targeting Istio 1.7.

The filter itself will work with Istio 1.7, but the example generated by wasme init is missing the version information from the runtime-config.json to allow it to deploy to Istio 1.7.

Fixes https://github.com/solo-io/wasm/issues/216