### PR TITLE
Bump setup-kind step in CI/CD

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -50,7 +50,7 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: '1.15.2'
-    - uses: engineerd/setup-kind@v0.3.0
+    - uses: engineerd/setup-kind@v0.5.0
       with:
         skipClusterCreation: "true"
     - name: Install Protoc
@@ -125,7 +125,7 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: '1.15.2'
-    - uses: engineerd/setup-kind@v0.3.0
+    - uses: engineerd/setup-kind@v0.5.0
       with:
         skipClusterCreation: "true"
     - name: Install Protoc

--- a/tools/wasme/changelog/v0.0.31/bump-kind-setup.yaml
+++ b/tools/wasme/changelog/v0.0.31/bump-kind-setup.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Update the setup-kind CI step to the latest version. Current version uses an API which is no longer supported by GitHub.


### PR DESCRIPTION
GH API has changed and is no longer supported, the new version of the GitHub Action uses the newer, supported API.