### PR TITLE
Update docs to reflect namespace create no longer required

### DIFF
--- a/tools/wasme/cli/docs/content/tutorial_code/getting_started/_index.md
+++ b/tools/wasme/cli/docs/content/tutorial_code/getting_started/_index.md
@@ -239,7 +239,7 @@ kubectl create ns gloo-system
 helm install --namespace gloo-system --set global.wasm.enabled=true gloo gloo/gloo
 {{< /tab >}}
 {{< tab name="glooctl" codelang="shell" >}}
-glooctl install gateway -n gloo-system --values <(echo '{"namespace":{"create":true},"crds":{"create":true},"global":{"wasm":{"enabled":true}}}')
+glooctl install gateway -n gloo-system --values <(echo '{"crds":{"create":true},"global":{"wasm":{"enabled":true}}}')
 {{< /tab >}}
 {{< /tabs >}}
 


### PR DESCRIPTION
Quick docs fix to reflect that "namespace": {"create":"true"} is no longer required when installing via `glooctl`.

Fixes https://github.com/solo-io/wasm/issues/62