### PR TITLE
Update e2e tests for Istio 1.8.x

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -101,10 +101,12 @@ jobs:
       fail-fast: false
       matrix:
         istio-version: [
-          '1.5.1',
           '1.6.6',
           '1.7.1',
-          '1.8.0-alpha.0'
+          '1.8.0-alpha.0',
+          '1.8.1',
+          '1.8.2',
+          '1.8.3'
         ]
         include:
           - istio-version: '1.6.6'

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -39,8 +39,8 @@ jobs:
           ${{ runner.os }}-go-
     - name: Generate Code
       run: |
-        curl -sSL https://get.helm.sh/helm-v3.2.0-linux-amd64.tar.gz | tar -xzf - linux-amd64/helm
-        export PATH=$PWD/linux-amd64:$PATH
+        cd $HOME && curl -sSL https://get.helm.sh/helm-v3.2.0-linux-amd64.tar.gz | tar -xzf - linux-amd64/helm && cd -
+        export PATH=$HOME/linux-amd64:$PATH
         cd ./tools/wasme/cli
         ./ci/check-code-and-docs-gen.sh
   test:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -40,9 +40,9 @@ jobs:
     - name: Install Helm
       run: |
         cd $HOME && curl -sSL https://get.helm.sh/helm-v3.2.0-linux-amd64.tar.gz | tar -xzf - linux-amd64/helm && cd -
-        export PATH=$HOME/linux-amd64:$PATH
     - name: Generate Code
       run: |
+        export PATH=$HOME/linux-amd64:$PATH
         cd ./tools/wasme/cli
         ./ci/check-code-and-docs-gen.sh
   test:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -39,6 +39,8 @@ jobs:
           ${{ runner.os }}-go-
     - name: Generate Code
       run: |
+        curl -sSL https://get.helm.sh/helm-v3.2.0-linux-amd64.tar.gz | tar -xzf - linux-amd64/helm
+        export PATH=$PWD/linux-amd64:$PATH
         cd ./tools/wasme/cli
         ./ci/check-code-and-docs-gen.sh
   test:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -37,10 +37,12 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-    - name: Generate Code
+    - name: Install Helm
       run: |
         cd $HOME && curl -sSL https://get.helm.sh/helm-v3.2.0-linux-amd64.tar.gz | tar -xzf - linux-amd64/helm && cd -
         export PATH=$HOME/linux-amd64:$PATH
+    - name: Generate Code
+      run: |
         cd ./tools/wasme/cli
         ./ci/check-code-and-docs-gen.sh
   test:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -107,9 +107,6 @@ jobs:
           '1.8.0-alpha.0'
         ]
         include:
-          - istio-version: '1.5.1'
-            istio-binary: 'https://github.com/istio/istio/releases/download/1.5.1/istio-1.5.1-linux.tar.gz'
-            istio-filter-image: 'webassemblyhub.io/ilackarms/assemblyscript-test:istio-1.5'
           - istio-version: '1.6.6'
             istio-binary: 'https://github.com/istio/istio/releases/download/1.6.6/istio-1.6.6-linux-amd64.tar.gz'
             istio-filter-image: 'webassemblyhub.io/ilackarms/assemblyscript-test:istio-1.5'
@@ -118,6 +115,15 @@ jobs:
             istio-filter-image: 'webassemblyhub.io/sodman/istio-1-7:v0.3'
           - istio-version: '1.8.0-alpha.0'
             istio-binary: 'https://github.com/istio/istio/releases/download/1.8.0-alpha.0/istio-1.8.0-alpha.0-linux-amd64.tar.gz'
+            istio-filter-image: 'webassemblyhub.io/sodman/istio-1-7:v0.3'
+          - istio-version: '1.8.1'
+            istio-binary: 'https://github.com/istio/istio/releases/download/1.8.1/istioctl-1.8.1-linux-amd64.tar.gz'
+            istio-filter-image: 'webassemblyhub.io/sodman/istio-1-7:v0.3'
+          - istio-version: '1.8.2'
+            istio-binary: 'https://github.com/istio/istio/releases/download/1.8.2/istioctl-1.8.2-linux-amd64.tar.gz'
+            istio-filter-image: 'webassemblyhub.io/sodman/istio-1-7:v0.3'
+          - istio-version: '1.8.3'
+            istio-binary: 'https://github.com/istio/istio/releases/download/1.8.3/istioctl-1.8.3-linux-amd64.tar.gz'
             istio-filter-image: 'webassemblyhub.io/sodman/istio-1-7:v0.3'
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -119,13 +119,13 @@ jobs:
             istio-binary: 'https://github.com/istio/istio/releases/download/1.8.0-alpha.0/istio-1.8.0-alpha.0-linux-amd64.tar.gz'
             istio-filter-image: 'webassemblyhub.io/sodman/istio-1-7:v0.3'
           - istio-version: '1.8.1'
-            istio-binary: 'https://github.com/istio/istio/releases/download/1.8.1/istioctl-1.8.1-linux-amd64.tar.gz'
+            istio-binary: 'https://github.com/istio/istio/releases/download/1.8.1/istio-1.8.1-linux-amd64.tar.gz'
             istio-filter-image: 'webassemblyhub.io/sodman/istio-1-7:v0.3'
           - istio-version: '1.8.2'
-            istio-binary: 'https://github.com/istio/istio/releases/download/1.8.2/istioctl-1.8.2-linux-amd64.tar.gz'
+            istio-binary: 'https://github.com/istio/istio/releases/download/1.8.2/istio-1.8.2-linux-amd64.tar.gz'
             istio-filter-image: 'webassemblyhub.io/sodman/istio-1-7:v0.3'
           - istio-version: '1.8.3'
-            istio-binary: 'https://github.com/istio/istio/releases/download/1.8.3/istioctl-1.8.3-linux-amd64.tar.gz'
+            istio-binary: 'https://github.com/istio/istio/releases/download/1.8.3/istio-1.8.3-linux-amd64.tar.gz'
             istio-filter-image: 'webassemblyhub.io/sodman/istio-1-7:v0.3'
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -103,10 +103,7 @@ jobs:
         istio-version: [
           '1.6.6',
           '1.7.1',
-          '1.8.0-alpha.0',
-          '1.8.1',
-          '1.8.2',
-          '1.8.3'
+          '1.8.4'
         ]
         include:
           - istio-version: '1.6.6'
@@ -115,17 +112,8 @@ jobs:
           - istio-version: '1.7.1'
             istio-binary: 'https://github.com/istio/istio/releases/download/1.7.1/istio-1.7.1-linux-amd64.tar.gz'
             istio-filter-image: 'webassemblyhub.io/sodman/istio-1-7:v0.3'
-          - istio-version: '1.8.0-alpha.0'
-            istio-binary: 'https://github.com/istio/istio/releases/download/1.8.0-alpha.0/istio-1.8.0-alpha.0-linux-amd64.tar.gz'
-            istio-filter-image: 'webassemblyhub.io/sodman/istio-1-7:v0.3'
-          - istio-version: '1.8.1'
-            istio-binary: 'https://github.com/istio/istio/releases/download/1.8.1/istio-1.8.1-linux-amd64.tar.gz'
-            istio-filter-image: 'webassemblyhub.io/sodman/istio-1-7:v0.3'
-          - istio-version: '1.8.2'
-            istio-binary: 'https://github.com/istio/istio/releases/download/1.8.2/istio-1.8.2-linux-amd64.tar.gz'
-            istio-filter-image: 'webassemblyhub.io/sodman/istio-1-7:v0.3'
-          - istio-version: '1.8.3'
-            istio-binary: 'https://github.com/istio/istio/releases/download/1.8.3/istio-1.8.3-linux-amd64.tar.gz'
+          - istio-version: '1.8.4'
+            istio-binary: 'https://github.com/istio/istio/releases/download/1.8.4/istio-1.8.4-linux-amd64.tar.gz'
             istio-filter-image: 'webassemblyhub.io/sodman/istio-1-7:v0.3'
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -156,7 +156,7 @@ jobs:
         KUBECTL: ${{ steps.kubectl.outputs.kubectl-path }}
       working-directory: ./tools/wasme/cli
       run: |
-        export PATH=$(dirname $KUBECTL):$PATH
+        export PATH=$PWD/linux-amd64:$(dirname $KUBECTL):$PATH
         export FILTER_IMAGE_ISTIO_TAG=${{ matrix.istio-filter-image }}
         export ISTIO_VERSION=${{ matrix.istio-version }}
         export TEST_PKG=pkg/deploy/istio/

--- a/tools/wasme/pkg/defaults/defaults.go
+++ b/tools/wasme/pkg/defaults/defaults.go
@@ -8,8 +8,6 @@ import (
 	"github.com/solo-io/wasm/tools/wasme/pkg/resolver"
 )
 
-// Trigger CI / Don't merge this.
-
 func NewDefaultCache() cache.Cache {
 	return cache.NewCache(NewDefaultPuller())
 }

--- a/tools/wasme/pkg/defaults/defaults.go
+++ b/tools/wasme/pkg/defaults/defaults.go
@@ -2,10 +2,13 @@ package defaults
 
 import (
 	"context"
+
 	"github.com/solo-io/wasm/tools/wasme/pkg/cache"
 	"github.com/solo-io/wasm/tools/wasme/pkg/pull"
 	"github.com/solo-io/wasm/tools/wasme/pkg/resolver"
 )
+
+// Trigger CI / Don't merge this.
 
 func NewDefaultCache() cache.Cache {
 	return cache.NewCache(NewDefaultPuller())


### PR DESCRIPTION
Update tests to use released version of Istio 1.8.x rather than the pre-release alpha version.

Also pins helm to 3.2 for codegen, to be consistent with the other tests.