### PR TITLE
Add a variant of Wasm image spec based on standard media types.

### DIFF
--- a/spec/README-compat.md
+++ b/spec/README-compat.md
@@ -3,29 +3,33 @@
 
 ## Introduction:
 
-This document describes a varient of [Wasm Artifact Image Specification](README.md), which leverages the OCI "compatible" media type. Here, we omit definition and terminology explained in [Wasm Artifact Image Specification](README.md). 
+This document describes a varient of [Wasm Artifact Image Specification](README.md), which leverages the standard media types. Here, we omit definition and terminology explained in [Wasm Artifact Image Specification](README.md). 
 
 We call this variant "compat", and the spec in [Wasm Artifact Image Specification](README.md) "oci".
 
 ## Description
 
-This *compat* variant makes use of `application/vnd.oci.image.layer.v1.tar+gzip` media type for layers, and is not based on custom OCI Artifcat media types. This way users can oeperate with standard tools such as docker, podman, buildah, etc.
+This *compat* variant makes use of standard media type for layers, and is not based on custom OCI Artifcat media types. This way users can oeperate with standard tools such as docker, podman, buildah, etc.
 
 ## Format
 
-### Annotation
-
-The *compat* variant must add the annotation `module.wasm.image/variant=compat` in the manifest.
-
 ### Layer
 
-The *compat* variant must consist of exactly one `application/vnd.oci.image.layer.v1.tar+gzip` layer containing the two files:
+The *compat* variant must consist of exactly one layer whose media type is one of the followings:
+- `application/vnd.oci.image.layer.v1.tar+gzip`
+- `application/vnd.docker.image.rootfs.diff.tar.gzip`
+
+In addition, the layer must consist of the following two files:
 - `plugin.wasm` - (**Required**) A Wasm binary to be loaded by the runtime.
 - `runtime-config.json` - (**Optional**) A runtime configuratio specified in [Wasm Artifact Image Specification](README.md).
 
-### Example
+### Annotation
 
-The following is an example OCI manifest of a *compat* variant image:
+If the media type equals `application/vnd.oci.image.layer.v1.tar+gzip`, then a *compat* variant image must add the annotation `module.wasm.image/variant=compat` in the manifest.
+
+### Example with `application/vnd.oci.image.layer.v1.tar+gzip` media type
+
+The following is an example OCI manifest of a *compat* variant image with `application/vnd.oci.image.layer.v1.tar+gzip` layer media type on:
 
 ```
 {
@@ -56,12 +60,34 @@ filter.wasm
 runtime-config.json
 ```
 
+### Example with `application/vnd.docker.image.rootfs.diff.tar.gzip` media type
+
+The following is an example OCI manifest of a *compat* variant image with `application/vnd.docker.image.rootfs.diff.tar.gzip` layer media type on:
+
+```
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+  "config": {
+    "mediaType": "application/vnd.docker.container.image.v1+json",
+    "size": 1182,
+    "digest": "sha256:500c5c9b0755790c440f6d24a8926e399913bda2d599dcac24edb99a72b66de7"
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+      "size": 161,
+      "digest": "sha256:cf72304d01ead8fe014ed9f09e4132678ee4f29030ec46e6242c457071435ec3"
+    }
+  ]
+}
+```
 
 ## Appendix: build a *compat* image with Buildah
 
-In this section, we demonstrate how to build a compiliant image with Buildah, a standard cli for building OCI images. We use v1.21.0 of Buildah here.
+In this section, we demonstrate how to build a compiliant image with Buildah, a standard cli for building OCI images. We use v1.21.0 of Buildah here. Produced images have `application/vnd.oci.image.layer.v1.tar+gzip` layer media type
 
-We assume that you have a valid Wasm binary named `filter.wasm` and `runtime-config.json` that you want to package as a Wasm OCI image.
+We assume that you have a valid Wasm binary named `filter.wasm` and `runtime-config.json` that you want to package as an image.
 
 First, we create a working container from `scratch` base image with `buildah from` command.
 
@@ -83,8 +109,37 @@ $ buildah copy mywasm filter.wasm runtime-config.json ./
 af82a227630327c24026d7c6d3057c3d5478b14426b74c547df011ca5f23d271
 ```
 
-Now, you can build a *compat* image and push it to your registries via `buildah commit` command
+Now, you can build a *compat* image and push it to your registry via `buildah commit` command
 
 ```
 $ buildah commit mywasm docker://my-remote-registry/mywasm:0.1.0
+```
+
+## Appendix: build a *compat* image with Docker CLI
+
+In this section, we demonstrate how to build a compiliant image with Docker CLI. Produced images have `application/vnd.docker.image.rootfs.diff.tar.gzip` layer media type.
+
+We assume that you have a valid Wasm binary named `filter.wasm` and `runtime-config.json` that you want to package as an image.
+
+First, we prepare the following Dockerfile:
+
+```
+$ cat Dockerfile
+FROM scratch
+
+COPY runtime-config.json plugin.wasm ./
+```
+
+(**Note: you must have exactly one `COPY` instruction in the Dockerfile in order to end up having only one layer in produced images**)
+
+Then, build your image via `docker build` command
+
+```
+$ docker build . -t my-registry/mywasm:0.1.0
+```
+
+Finally, push the image to your registry via `docker push` command
+
+```
+$ docker push my-registry/mywasm:0.1.0
 ```

--- a/spec/README-compat.md
+++ b/spec/README-compat.md
@@ -1,0 +1,84 @@
+
+# Wasm Image Specification v0.0.0
+
+## Introduction:
+
+This document describes a varient of [Wasm Artifact Image Specification](README.md), which leverages the OCI "compatible" media type. Here, we omit definition and terminology explained in [Wasm Artifact Image Specification](README.md). 
+
+We call this variant "compat", and the spec in [Wasm Artifact Image Specification](README.md) "oci".
+
+## Description
+
+This *compat* variant makes use of `application/vnd.oci.image.layer.v1.tar+gzip` media type for layers, and is not based on custom OCI Artifcat media types. This way users can oeperate with standard tools such as docker, podman, buildah, etc.
+
+## Format
+
+### Annotation
+
+The *compat* variant must add the annotation `module.wasm.image/variant=compat` in the manifest.
+
+### Layer
+
+The *compat* variant must consist of exactly one `application/vnd.oci.image.layer.v1.tar+gzip` layer containing the two files:
+- `filter.wasm` - (**Required**) A Wasm binary to be loaded by the runtime.
+- `runtime-config.json` - (**Optional**) A runtime configuratio specified in [Wasm Artifact Image Specification](README.md).
+
+### Example
+
+The following is an example OCI manifest of a *compat* variant image:
+
+```
+{
+  "schemaVersion": 2,
+  "config": {
+    "mediaType": "application/vnd.oci.image.config.v1+json",
+    "digest": "sha256:933594cea89247a78932eb9d74fae998e6fc3d1d114a7ff7705aaf702dbf7edb",
+    "size": 326
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+      "digest": "sha256:e05c6f7d59f4c5976d9c1be8e12c34f64c49e5541967581e7f052070705191ac",
+      "size": 151
+    }
+  ],
+  "annotations": {
+    "module.wasm.image/variant": "compat"
+  }
+}
+```
+
+And the contents in the layer consists of two files mentioned above
+
+```
+$ tar tf blobs/sha256/e05c6f7d59f4c5976d9c1be8e12c34f64c49e5541967581e7f052070705191ac
+filter.wasm
+runtime-config.json
+```
+
+
+## Appendix: build a *compat* image with Buildah
+
+In this section, we demonstrate how to build a compiliant image with Buildah, a standard cli for building OCI images. We use v1.21.0 of Buildah here.
+
+We assume that you have a valid Wasm binary named `filter.wasm` and `runtime-config.json` that you want to package as a Wasm OCI image.
+
+First, we create a working container from `scratch` base image with `buildah from` command.
+
+```
+$ buildah --name mywasm from scratch
+mywasm
+```
+
+Then copy the files into that base image by `buildah copy` command to create the layer.
+
+```
+$ buildah copy mywasm filter.wasm runtime-config.json ./
+af82a227630327c24026d7c6d3057c3d5478b14426b74c547df011ca5f23d271
+```
+
+Now, you can build a *compat* image and push it to your registries via `buildah commit` command
+
+```
+$ buildah commit mywasm docker://my-remote-registry/mywasm:0.1.0
+```

--- a/spec/README-compat.md
+++ b/spec/README-compat.md
@@ -113,7 +113,7 @@ $ buildah commit mywasm docker://my-remote-registry/mywasm:0.1.0
 
 We demonstrate how to build a *compat* image with Docker CLI. Produced images have `application/vnd.docker.image.rootfs.diff.tar.gzip` layer media type.
 
-We assume that you have a valid Wasm binary named `filter.wasm` and `runtime-config.json` that you want to package as an image.
+We assume that you have a valid Wasm binary named `plugin.wasm` and `runtime-config.json` that you want to package as an image.
 
 First, we prepare the following Dockerfile:
 

--- a/spec/README-compat.md
+++ b/spec/README-compat.md
@@ -20,7 +20,7 @@ The *compat* variant must add the annotation `module.wasm.image/variant=compat` 
 ### Layer
 
 The *compat* variant must consist of exactly one `application/vnd.oci.image.layer.v1.tar+gzip` layer containing the two files:
-- `filter.wasm` - (**Required**) A Wasm binary to be loaded by the runtime.
+- `plugin.wasm` - (**Required**) A Wasm binary to be loaded by the runtime.
 - `runtime-config.json` - (**Optional**) A runtime configuratio specified in [Wasm Artifact Image Specification](README.md).
 
 ### Example

--- a/spec/README-compat.md
+++ b/spec/README-compat.md
@@ -70,6 +70,12 @@ $ buildah --name mywasm from scratch
 mywasm
 ```
 
+Next, add the annotation described above via `buildah config` command
+
+```
+$ buildah config --annotation "module.wasm.image/variant=compat" mywasm
+```
+
 Then copy the files into that base image by `buildah copy` command to create the layer.
 
 ```

--- a/spec/README-compat.md
+++ b/spec/README-compat.md
@@ -3,7 +3,7 @@
 
 ## Introduction:
 
-This document describes a varient of [Wasm Artifact Image Specification](README.md), which leverages the standard media types. Here, we omit definition and terminology explained in [Wasm Artifact Image Specification](README.md). 
+This document describes a varient of [Wasm Artifact Image Specification](README.md), which leverages the standard layer media types. Here, we omit definition and terminology explained in [Wasm Artifact Image Specification](README.md). 
 
 We call this variant "compat", and the spec in [Wasm Artifact Image Specification](README.md) "oci".
 
@@ -11,7 +11,7 @@ We call this variant "compat", and the spec in [Wasm Artifact Image Specificatio
 
 This *compat* variant makes use of standard media type for layers, and is not based on custom OCI Artifcat media types. This way users can oeperate with standard tools such as docker, podman, buildah, etc.
 
-## Format
+## Specification
 
 ### Layer
 
@@ -52,14 +52,6 @@ The following is an example OCI manifest of a *compat* variant image with `appli
 }
 ```
 
-And the contents in the layer consists of two files mentioned above
-
-```
-$ tar tf blobs/sha256/e05c6f7d59f4c5976d9c1be8e12c34f64c49e5541967581e7f052070705191ac
-filter.wasm
-runtime-config.json
-```
-
 ### Example with `application/vnd.docker.image.rootfs.diff.tar.gzip` media type
 
 The following is an example OCI manifest of a *compat* variant image with `application/vnd.docker.image.rootfs.diff.tar.gzip` layer media type on:
@@ -85,7 +77,7 @@ The following is an example OCI manifest of a *compat* variant image with `appli
 
 ## Appendix: build a *compat* image with Buildah
 
-In this section, we demonstrate how to build a compiliant image with Buildah, a standard cli for building OCI images. We use v1.21.0 of Buildah here. Produced images have `application/vnd.oci.image.layer.v1.tar+gzip` layer media type
+We demonstrate how to build a *compat* image with Buildah, a standard cli for building OCI images. We use v1.21.0 of Buildah here. Produced images have `application/vnd.oci.image.layer.v1.tar+gzip` layer media type
 
 We assume that you have a valid Wasm binary named `filter.wasm` and `runtime-config.json` that you want to package as an image.
 
@@ -109,6 +101,8 @@ $ buildah copy mywasm filter.wasm runtime-config.json ./
 af82a227630327c24026d7c6d3057c3d5478b14426b74c547df011ca5f23d271
 ```
 
+**Note: you must execute `buildah copy` exactly once in order to end up having only one layer in produced images**
+
 Now, you can build a *compat* image and push it to your registry via `buildah commit` command
 
 ```
@@ -117,7 +111,7 @@ $ buildah commit mywasm docker://my-remote-registry/mywasm:0.1.0
 
 ## Appendix: build a *compat* image with Docker CLI
 
-In this section, we demonstrate how to build a compiliant image with Docker CLI. Produced images have `application/vnd.docker.image.rootfs.diff.tar.gzip` layer media type.
+We demonstrate how to build a *compat* image with Docker CLI. Produced images have `application/vnd.docker.image.rootfs.diff.tar.gzip` layer media type.
 
 We assume that you have a valid Wasm binary named `filter.wasm` and `runtime-config.json` that you want to package as an image.
 
@@ -130,7 +124,7 @@ FROM scratch
 COPY runtime-config.json plugin.wasm ./
 ```
 
-(**Note: you must have exactly one `COPY` instruction in the Dockerfile in order to end up having only one layer in produced images**)
+**Note: you must have exactly one `COPY` instruction in the Dockerfile in order to end up having only one layer in produced images**
 
 Then, build your image via `docker build` command
 

--- a/spec/README-compat.md
+++ b/spec/README-compat.md
@@ -9,7 +9,7 @@ We call this variant "compat", and the spec in [Wasm Artifact Image Specificatio
 
 ## Description
 
-This *compat* variant makes use of standard media type for layers, and is not based on custom OCI Artifcat media types. This way users can oeperate with standard tools such as docker, podman, buildah, etc.
+This *compat* variant makes use of standard media type for layers, and is not based on custom OCI Artifact media types. This way users can oeperate with standard tools such as docker, podman, buildah, etc.
 
 ## Specification
 

--- a/spec/README-compat.md
+++ b/spec/README-compat.md
@@ -29,7 +29,7 @@ If the media type equals `application/vnd.oci.image.layer.v1.tar+gzip`, then a *
 
 ### Example with `application/vnd.oci.image.layer.v1.tar+gzip` media type
 
-The following is an example OCI manifest of a *compat* variant image with `application/vnd.oci.image.layer.v1.tar+gzip` layer media type on:
+The following is an example OCI manifest of images with `application/vnd.oci.image.layer.v1.tar+gzip` layer media type:
 
 ```
 {
@@ -54,7 +54,7 @@ The following is an example OCI manifest of a *compat* variant image with `appli
 
 ### Example with `application/vnd.docker.image.rootfs.diff.tar.gzip` media type
 
-The following is an example OCI manifest of a *compat* variant image with `application/vnd.docker.image.rootfs.diff.tar.gzip` layer media type on:
+The following is an example Docker manifest of images with `application/vnd.docker.image.rootfs.diff.tar.gzip` layer media type:
 
 ```
 {
@@ -75,7 +75,7 @@ The following is an example OCI manifest of a *compat* variant image with `appli
 }
 ```
 
-## Appendix: build a *compat* image with Buildah
+## Appendix 1: build a *compat* image with Buildah
 
 We demonstrate how to build a *compat* image with Buildah, a standard cli for building OCI images. We use v1.21.0 of Buildah here. Produced images have `application/vnd.oci.image.layer.v1.tar+gzip` layer media type
 
@@ -109,7 +109,7 @@ Now, you can build a *compat* image and push it to your registry via `buildah co
 $ buildah commit mywasm docker://my-remote-registry/mywasm:0.1.0
 ```
 
-## Appendix: build a *compat* image with Docker CLI
+## Appendix 2: build a *compat* image with Docker CLI
 
 We demonstrate how to build a *compat* image with Docker CLI. Produced images have `application/vnd.docker.image.rootfs.diff.tar.gzip` layer media type.
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -11,7 +11,7 @@ The Wasm Image specification defines how to bundle Wasm modules as container ima
 | Wasm Module                        | The distributable, loadable, and executable unit of code in WebAssembly. 
 | Wasm Image Specification           | The specification for storing Wasm modules as container images.
 | Wasm Runtime                       | The execution environment into which a Wasm Module may be loaded. This refers to the application itself which loads and executes a wasm module. Examples include web browsers, the Open Policy Agent, the Envoy Proxy, or any other application which supports extension via Wasm modules. 
-| Rurntime Configuation              | Configuration or metadata specific to the runtime which consumes a module. 
+| Runtime Configuation              | Configuration or metadata specific to the runtime which consumes a module. 
 
 ## Specifications
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,133 +1,49 @@
+# Wasm Image specifications
 
-## WASM Artifact Image Specification v0.0.0
+## Overview
 
-- [Introduction](#introduction)
-- [Terminology](#terminology)
-- [Description](#description)
-    - [Overview](#overview)
-    - [Layers](#layers)
-    - [Running OCI Images with Envoy](#running-oci-images-with-envoy)
-- [Format](#format)
-- [Envoy WASM Filter Specification](#envoy-wasm-filter-specification)
-    - [Example](#example)
+Here we have several specifications for how to bundle Wasm modules as container images. 
+They primarily consider the use case of [Envoy] Wasm plugins in [Istio] service mesh.
 
+There are two variants of the specification:
+- [spec.md](spec.md)
+- [spec-compat.md](spec-compat.md)
 
-### Introduction:
+Developers and Wasm module consumers can leverage both of these specifications. 
 
-The WASM Artifact Image Specification defines how to bundle WASM modules as OCI images. WASM Artifact Images consist of a WASM binary file, configuration file, and metadata for the target WASM runtime.
+For clarity, we call the variant in [spec.md](spec.md) *oci*, and the one in [spec-compat.md](spec-compat.md) *compat*.
 
-The spec is intended to be generic, allowing for any type of WASM module whether it is used to extend any Envoy, OPA, or the browser.
+## Difference between variants
 
-The spec can be considered an extension of the OCI Artifact Spec designed specifically for use by applications which produce and consume WASM modules (as opposed to application containers). It is intended to provide a standard mechanism to manage the building and running of WASM modules. 
+The key difference between these two variants is that, the *oci* variant makes use of the custom media types on [OCI Artifact] for image layers while the *compat* variant leverages the standard media types.
 
-This document considers primarily the use case of storing WASM Envoy Filters as OCI Images.
+As a consequence, that introduces the difference in tools available for building and pushing images. 
+For example, the only way to build and push *oci* variant images is to use [`wasme`] cli while you can use [`buildah`] or [`docker`] for *compat* variant images.
 
-### Terminology:
+Not only that, the usage of custom media types on top of [OCI Artifact] requires registries to support arbitrary custom media types. Therefore, you might not be able to push *oci* variants to your registry while [WebAssemblyHub] is designed for accepting them.
 
-| Term                               | Definition                                       |
-|------------------------------------|--------------------------------------------------|
-| WASM Module                        | The distributable, loadable, and executable unit of code in WebAssembly. 
-| WASM OCI Image Specification       | The specification for storing WASM modules as OCI Images.
-| WASM Runtime                       | The execution environment into which a WASM Module may be loaded. This refers to the application itself which loads and executes a wasm module. Examples include web browsers, the Open Policy Agent, the Envoy Proxy, or any other application which supports extension via WASM modules. 
-| Runtime Configuration              | Configuration specific to the runtime which consumes a module. This configuration is stored as JSON and bundled with the module in the image in the specification. 
-| Envoy WASM Filter                  | Custom Filters for the Envoy Proxy built as a WASM module.
-| Envoy WASM OCI Image               | Envoy Filters stored as OCI images according to the specification. 
-| Envoy WASM OCI Artifact Specification | An extension of the WASM OCI Artifact Spec which describes how to bundle and ship Envoy WASM filters as OCI Images. |
+## Wasm image support in [Istio]
 
-### Description:
+Istio's Wasm Plugin API has support for **both of these variants** to deploy your Wasm plugins into Envoy sidecars. 
 
-#### Overview:
+### Which variant should I use in [Istio]?
 
-The WASM OCI Artifact Specification defines a method of storing WASM modules which makes them easy to build, pull, publish, and execute.
+Given that Istio supports both of variants, you can choose whichever variant depending on your needs. For example, if you want to use [`docker`] cli, then choose *compat* variant and push them to your container registries. You might want to use [`wasme`] cli and [WebAssemblyHub] then choose the *oci* variant.
 
-Because each execution environment (runtime) for a WASM module may have runtime-specific configuration parameters, a WASM image is composed of both a content layer, for the WASM module itself, as well as a config layer, with metadata describing the module which is relevant to the target runtime.
+## How can I build images?
 
-#### Layers:
+For *oci* variant, see the guideline by [`wasme`].
 
-The content layer always consists of the WASM module binary. 
-
-The config layer consists of a JSON-formatted string, which contains metadata for the target runtime. The runtime and ABI (Application Binary Interface) versions of an image can be deduced by parsing the config layer. 
-
-The config layer may also contain additional data, depending on the target runtime. For example, the config for a WASM Envoy Filter contains root_ids available on the filter. 
-
-For the sake of simplicity, the specification only supports a single module per image.
-
-#### Running OCI Images with Envoy:
-
-Envoy supports loading and running WASM modules via a file on local disk or an “Http datasource”.
-
-Envoy WASM Filters can be stored according to the spec and run with Istio and Gloo, with the help of a local cache which pulls images from remote registries.  
-
-Control planes then configure the Envoy instances to load the filter via the local cache, using the required root_id parameter supplied in the image config if it is available.
+For *compat* variant, follow the instructions in 
+- [build a compat image with buildah](spec-compat.md#appendix-1-build-a-compat-image-with-buildah) if you want to use [`buildah`].
+- [build a compat image with docker](spec-compat.md#appendix-2-build-a-compat-image-with-docker-cli) if you want to use [`docker`].
 
 
-### Format:
+[Envoy]: https://github.com/envoyproxy/envoy
+[Istio]: https://github.com/istio/istio
+[OCI Artifact]: https://github.com/opencontainers/artifacts
+[WebAssemblyHub]: https://webassemblyhub.io/
 
-The WASM OCI Artifact Spec consists of two layers bundled together:
-- A layer specifying configuration for the target runtime
-- A layer containing the compiled WASM module itself
-
-Each layer is associated with its own Media Type, which is stored in the OCI Descriptor for that layer:
-
-| Media Type | Type | Description |
-|------------|------|-------------|
-| application/vnd.module.wasm.config.v1+json | JSON Object | Configuration for the Target WASM runtime.
-| application/vnd.module.wasm.content.layer.v1+wasm | binary data (byte array) | The compiled module data |
-
-`application/vnd.module.wasm.config.v1+json` Property Descriptions:
-
-| Property   | Type | Description |
-|------------|------|-------------|
-| type | string | Name of the target runtime. Required. Specifies the intended runtime of the bundled module. The content of the Opaque JSON Config is specific to the type of WASM runtime. 
-| abiVersions | string array | List of ABI Versions for the target runtime with which the image is compatible. The format for the version is dependent upon the runtime itself.
-| config | JSON Object | This field stores any configuration parameters required by the target runtime. Its structure depends on the specified runtime. |
-
-
-### Envoy WASM Filter Specification
-
-The runtime config for Envoy WASM Filter OCI Images has the following format:
-
-- *type* is set to `envoy_proxy`
-- *abiVersion* is set to a recognized version of the Envoy Proxy WASM Filter ABI 
-- *config* is a JSON Object containing a list of Filter root_ids that can be used with the provided filter
-
-The `root_ids` key in the *config* JSON Object will have a list of strings as a value. Each string in the list corresponds to the name of a registered Root Context Helper defined in the module.
-
-#### Example:
-
-The following descriptors provide an example of the OCI Image descriptors for an Envoy WASM Filter stored according to the specification:
-```
-[
-  {
-    "mediaType": "application/vnd.module.wasm.config.v1+json",
-    "digest": "sha256:d0a165298ae270c5644be8e9938036a3a7a5191f6be03286c40874d761c18abf",
-    "size": 125,
-    "annotations": {
-      "org.opencontainers.image.title": "runtime-config.json"
-    }
-  },
-  {
-    "mediaType": "application/vnd.module.wasm.content.layer.v1+wasm",
-    "digest": "sha256:5e82b945b59d03620fb360193753cbd08955e30a658dc51735a0fcbc2163d41c",
-    "size": 1043056,
-    "annotations": {
-      "org.opencontainers.image.title": "filter.wasm"
-    }
-  }
-]
-```
-
-The following is the runtime config stored as the `application/vnd.module.wasm.config.v1+json` layer:
-
-```{
-  "type": "envoy_proxy",
-  "abi_version": "v0-541b2c1155fffb15ccde92b8324f3e38f7339ba6",
-  "config": {
-    "root_ids": [
-      "add_header_root_id"
-    ]
-  }
-}
-```
-
-You can use the `wasme` tool to take new or existing module code and package it according to the WASM OCI Spec.
+[`docker`]: https://docs.docker.com/engine/reference/commandline/cli/
+[`buildah`]: https://github.com/containers/buildah
+[`wasme`]: https://docs.solo.io/web-assembly-hub/latest/installation/

--- a/spec/README.md
+++ b/spec/README.md
@@ -3,7 +3,7 @@
 ## Overview
 
 Here we have several specifications for how to bundle Wasm modules as container images. 
-They primarily consider the use case of [Envoy] Wasm plugins in [Istio] service mesh.
+They primarily consider the use case of [Envoy] Wasm plugins.
 
 There are two variants of the specification:
 - [spec.md](spec.md)

--- a/spec/README.md
+++ b/spec/README.md
@@ -27,7 +27,9 @@ For clarity, we call the variant in [spec.md](spec.md) *oci*, and the one in [sp
 
 ## Difference between variants
 
-The key difference between these two variants is that, the *oci* variant makes use of the custom media types on [OCI Artifact] for image layers while the *compat* variant leverages the standard media types.
+Our goal is to make the *oci* variant the default format for shipping Wasm modules in container images, we acknowledge however that there are toolchains and registries deployed and in use that do not support our custom media types yet. To accomodate those exisiting toolchains, there is the semantically equivalent *compat* variant, which provides the same feature set, but is compatible with existing tooling because it 'looks' very much like a normal container image. Implementations of this spec should support both variants.
+
+With that said, the key difference between these two variants is that, the *oci* variant makes use of the custom media types on [OCI Artifact] for image layers while the *compat* variant leverages the standard media types.
 
 As a consequence, that introduces the difference in tools available for building and pushing images. 
 For example, the only way to build and push *oci* variant images is to use [`wasme`] cli while you can use [`buildah`] or [`docker`] for *compat* variant images.

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,9 +1,21 @@
 # Wasm Image specifications
 
-## Overview
+## Introduction
+
+The Wasm Image specification defines how to bundle Wasm modules as container images. A compatible Wasm image consists of a Wasm binary file, and runtime metadata for the target Wasm runtime. We primarily consider the use case of [Envoy] as Wasm runtime and its Wasm filter/plugins, although the spec is intended to be generic and to provide a standard mechanism to manage the building and running of Wasm modules on any Wasm runtime.
+
+## Terminology:
+
+| Term                               | Definition                                       |
+|------------------------------------|--------------------------------------------------|
+| Wasm Module                        | The distributable, loadable, and executable unit of code in WebAssembly. 
+| Wasm Image Specification           | The specification for storing Wasm modules as container images.
+| Wasm Runtime                       | The execution environment into which a Wasm Module may be loaded. This refers to the application itself which loads and executes a wasm module. Examples include web browsers, the Open Policy Agent, the Envoy Proxy, or any other application which supports extension via Wasm modules. 
+| Rurntime Configuation              | Configuration or metadata specific to the runtime which consumes a module. 
+
+## Specifications
 
 Here we have several specifications for how to bundle Wasm modules as container images. 
-They primarily consider the use case of [Envoy] Wasm plugins.
 
 There are two variants of the specification:
 - [spec.md](spec.md)
@@ -24,7 +36,7 @@ Not only that, the usage of custom media types on top of [OCI Artifact] requires
 
 ## Wasm image support in [Istio]
 
-Istio's Wasm Plugin API has support for **both of these variants** to deploy your Wasm plugins into Envoy sidecars. 
+Istio's Wasm Plugin API has support for **both of these variants** to deploy your Wasm plugins into Envoy sidecars.
 
 ### Which variant should I use in [Istio]?
 

--- a/spec/spec-compat.md
+++ b/spec/spec-compat.md
@@ -79,7 +79,7 @@ The following is an example Docker manifest of images with `application/vnd.dock
 
 We demonstrate how to build a *compat* image with Buildah, a standard cli for building OCI images. We use v1.21.0 of Buildah here. Produced images have `application/vnd.oci.image.layer.v1.tar+gzip` layer media type
 
-We assume that you have a valid Wasm binary named `filter.wasm` and `runtime-config.json` that you want to package as an image.
+We assume that you have a valid Wasm binary named `plugin.wasm` and `runtime-config.json` that you want to package as an image.
 
 First, we create a working container from `scratch` base image with `buildah from` command.
 
@@ -97,7 +97,7 @@ $ buildah config --annotation "module.wasm.image/variant=compat" mywasm
 Then copy the files into that base image by `buildah copy` command to create the layer.
 
 ```
-$ buildah copy mywasm filter.wasm runtime-config.json ./
+$ buildah copy mywasm plugin.wasm runtime-config.json ./
 af82a227630327c24026d7c6d3057c3d5478b14426b74c547df011ca5f23d271
 ```
 

--- a/spec/spec-compat.md
+++ b/spec/spec-compat.md
@@ -3,13 +3,13 @@
 
 ## Introduction:
 
-This document describes a varient of [Wasm Artifact Image Specification](README.md), which leverages the standard layer media types. Here, we omit definition and terminology explained in [Wasm Artifact Image Specification](README.md). 
+This document describes a varient of [Wasm Artifact Image Specification](spec.md), which leverages the compatible layer media types. Here, we omit definition and terminology explained in [Wasm Artifact Image Specification](spec.md). 
 
-We call this variant "compat", and the spec in [Wasm Artifact Image Specification](README.md) "oci".
+We call this variant "compat", and the spec in [Wasm Artifact Image Specification](spec.md) "oci".
 
 ## Description
 
-This *compat* variant makes use of standard media type for layers, and is not based on custom OCI Artifact media types. This way users can oeperate with standard tools such as docker, podman, buildah, etc.
+This *compat* variant makes use of compatible media type for layers, and is not based on custom OCI Artifact media types. This way users can oeperate with standard tools such as docker, podman, buildah, etc.
 
 ## Specification
 
@@ -21,7 +21,7 @@ The *compat* variant must consist of exactly one layer whose media type is one o
 
 In addition, the layer must consist of the following two files:
 - `plugin.wasm` - (**Required**) A Wasm binary to be loaded by the runtime.
-- `runtime-config.json` - (**Optional**) A runtime configuratio specified in [Wasm Artifact Image Specification](README.md).
+- `runtime-config.json` - (**Optional**) A runtime configuration specified in [Wasm Artifact Image Specification](spec.md#Format).
 
 ### Annotation
 

--- a/spec/spec-compat.md
+++ b/spec/spec-compat.md
@@ -3,13 +3,13 @@
 
 ## Introduction:
 
-This document describes a varient of [Wasm Artifact Image Specification](spec.md), which leverages the compatible layer media types. Here, we omit definition and terminology explained in [Wasm Artifact Image Specification](spec.md). 
+This document describes a variant of [Wasm Artifact Image Specification](spec.md), which leverages the compatible layer media types. Here, we omit definition and terminology explained in [Wasm Artifact Image Specification](spec.md). 
 
 We call this variant "compat", and the spec in [Wasm Artifact Image Specification](spec.md) "oci".
 
 ## Description
 
-This *compat* variant makes use of compatible media type for layers, and is not based on custom OCI Artifact media types. This way users can oeperate with standard tools such as docker, podman, buildah, etc.
+This *compat* variant makes use of compatible media type for layers, and is not based on custom OCI Artifact media types. This way users can operate with standard tools such as docker, podman, buildah, and standard container registries which don't yet support custom media types as used in [*oci* variant](spec.md).
 
 ## Specification
 

--- a/spec/spec-compat.md
+++ b/spec/spec-compat.md
@@ -25,7 +25,7 @@ In addition, the layer must consist of the following two files:
 
 ### Annotation
 
-If the media type equals `application/vnd.oci.image.layer.v1.tar+gzip`, then a *compat* variant image must add the annotation `module.wasm.image/variant=compat` in the manifest.
+If the media type equals `application/vnd.oci.image.layer.v1.tar+gzip`, then a *compat* variant image *should* add the annotation `module.wasm.image/variant=compat` in the manifest to make it easy to distinguish this *compat* variant from the *oci* variant. Note that this is **optional**.
 
 ### Example with `application/vnd.oci.image.layer.v1.tar+gzip` media type
 
@@ -81,20 +81,23 @@ We demonstrate how to build a *compat* image with Buildah, a standard cli for bu
 
 We assume that you have a valid Wasm binary named `plugin.wasm` and `runtime-config.json` (optional) that you want to package as an image.
 
-First, we create a working container from `scratch` base image with `buildah from` command.
+1. First, we create a working container from `scratch` base image with `buildah from` command.
 
 ```
 $ buildah --name mywasm from scratch
 mywasm
 ```
 
-Next, add the annotation described above via `buildah config` command
+2. Next, add the annotation described above via `buildah config` command
 
 ```
 $ buildah config --annotation "module.wasm.image/variant=compat" mywasm
 ```
 
-Then copy the files into that base image by `buildah copy` command to create the layer.
+**Note this step is optional. See [Annotation](#annotation) section.**
+
+
+3. Then copy the files into that base image by `buildah copy` command to create the layer.
 
 ```
 $ buildah copy mywasm plugin.wasm runtime-config.json ./
@@ -103,7 +106,7 @@ af82a227630327c24026d7c6d3057c3d5478b14426b74c547df011ca5f23d271
 
 **Note: you must execute `buildah copy` exactly once in order to end up having only one layer in produced images**
 
-Now, you can build a *compat* image and push it to your registry via `buildah commit` command
+4. Now, you can build a *compat* image and push it to your registry via `buildah commit` command
 
 ```
 $ buildah commit mywasm docker://my-remote-registry/mywasm:0.1.0
@@ -115,7 +118,7 @@ We demonstrate how to build a *compat* image with Docker CLI. Produced images ha
 
 We assume that you have a valid Wasm binary named `plugin.wasm` and `runtime-config.json` (optional) that you want to package as an image.
 
-First, we prepare the following Dockerfile:
+1. First, we prepare the following Dockerfile:
 
 ```
 $ cat Dockerfile
@@ -126,13 +129,13 @@ COPY runtime-config.json plugin.wasm ./
 
 **Note: you must have exactly one `COPY` instruction in the Dockerfile in order to end up having only one layer in produced images**
 
-Then, build your image via `docker build` command
+2. Then, build your image via `docker build` command
 
 ```
 $ docker build . -t my-registry/mywasm:0.1.0
 ```
 
-Finally, push the image to your registry via `docker push` command
+3. Finally, push the image to your registry via `docker push` command
 
 ```
 $ docker push my-registry/mywasm:0.1.0

--- a/spec/spec-compat.md
+++ b/spec/spec-compat.md
@@ -21,7 +21,7 @@ The *compat* variant must consist of exactly one layer whose media type is one o
 
 In addition, the layer must consist of the following two files:
 - `plugin.wasm` - (**Required**) A Wasm binary to be loaded by the runtime.
-- `runtime-config.json` - (**Optional**) A runtime configuration specified in [Wasm Artifact Image Specification](spec.md#Format).
+- `runtime-config.json` - (**Optional**) A runtime configuration specified in [Wasm Artifact Image Specification](spec.md#Format). This is mainly used as metadata for the image, depending on the runtime.
 
 ### Annotation
 
@@ -79,7 +79,7 @@ The following is an example Docker manifest of images with `application/vnd.dock
 
 We demonstrate how to build a *compat* image with Buildah, a standard cli for building OCI images. We use v1.21.0 of Buildah here. Produced images have `application/vnd.oci.image.layer.v1.tar+gzip` layer media type
 
-We assume that you have a valid Wasm binary named `plugin.wasm` and `runtime-config.json` that you want to package as an image.
+We assume that you have a valid Wasm binary named `plugin.wasm` and `runtime-config.json` (optional) that you want to package as an image.
 
 First, we create a working container from `scratch` base image with `buildah from` command.
 
@@ -113,7 +113,7 @@ $ buildah commit mywasm docker://my-remote-registry/mywasm:0.1.0
 
 We demonstrate how to build a *compat* image with Docker CLI. Produced images have `application/vnd.docker.image.rootfs.diff.tar.gzip` layer media type.
 
-We assume that you have a valid Wasm binary named `plugin.wasm` and `runtime-config.json` that you want to package as an image.
+We assume that you have a valid Wasm binary named `plugin.wasm` and `runtime-config.json` (optional) that you want to package as an image.
 
 First, we prepare the following Dockerfile:
 

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -1,35 +1,18 @@
 
 ## WASM Artifact Image Specification v0.0.0
 
-- [Introduction](#introduction)
 - [Terminology](#terminology)
 - [Description](#description)
-    - [Overview](#overview)
     - [Layers](#layers)
     - [Running OCI Images with Envoy](#running-oci-images-with-envoy)
 - [Format](#format)
 - [Envoy WASM Filter Specification](#envoy-wasm-filter-specification)
     - [Example](#example)
 
-
-### Introduction:
-
-The WASM Artifact Image Specification defines how to bundle WASM modules as OCI images. WASM Artifact Images consist of a WASM binary file, configuration file, and metadata for the target WASM runtime.
-
-The spec is intended to be generic, allowing for any type of WASM module whether it is used to extend any Envoy, OPA, or the browser.
-
-The spec can be considered an extension of the OCI Artifact Spec designed specifically for use by applications which produce and consume WASM modules (as opposed to application containers). It is intended to provide a standard mechanism to manage the building and running of WASM modules. 
-
-This document considers primarily the use case of storing WASM Envoy Filters as OCI Images.
-
 ### Terminology:
 
 | Term                               | Definition                                       |
 |------------------------------------|--------------------------------------------------|
-| WASM Module                        | The distributable, loadable, and executable unit of code in WebAssembly. 
-| WASM OCI Image Specification       | The specification for storing WASM modules as OCI Images.
-| WASM Runtime                       | The execution environment into which a WASM Module may be loaded. This refers to the application itself which loads and executes a wasm module. Examples include web browsers, the Open Policy Agent, the Envoy Proxy, or any other application which supports extension via WASM modules. 
-| Runtime Configuration              | Configuration specific to the runtime which consumes a module. This configuration is stored as JSON and bundled with the module in the image in the specification. 
 | Envoy WASM Filter                  | Custom Filters for the Envoy Proxy built as a WASM module.
 | Envoy WASM OCI Image               | Envoy Filters stored as OCI images according to the specification. 
 | Envoy WASM OCI Artifact Specification | An extension of the WASM OCI Artifact Spec which describes how to bundle and ship Envoy WASM filters as OCI Images. |
@@ -37,8 +20,6 @@ This document considers primarily the use case of storing WASM Envoy Filters as 
 ### Description:
 
 #### Overview:
-
-The WASM OCI Artifact Specification defines a method of storing WASM modules which makes them easy to build, pull, publish, and execute.
 
 Because each execution environment (runtime) for a WASM module may have runtime-specific configuration parameters, a WASM image is composed of both a content layer, for the WASM module itself, as well as a config layer, with metadata describing the module which is relevant to the target runtime.
 

--- a/spec/spec.md
+++ b/spec/spec.md
@@ -1,0 +1,133 @@
+
+## WASM Artifact Image Specification v0.0.0
+
+- [Introduction](#introduction)
+- [Terminology](#terminology)
+- [Description](#description)
+    - [Overview](#overview)
+    - [Layers](#layers)
+    - [Running OCI Images with Envoy](#running-oci-images-with-envoy)
+- [Format](#format)
+- [Envoy WASM Filter Specification](#envoy-wasm-filter-specification)
+    - [Example](#example)
+
+
+### Introduction:
+
+The WASM Artifact Image Specification defines how to bundle WASM modules as OCI images. WASM Artifact Images consist of a WASM binary file, configuration file, and metadata for the target WASM runtime.
+
+The spec is intended to be generic, allowing for any type of WASM module whether it is used to extend any Envoy, OPA, or the browser.
+
+The spec can be considered an extension of the OCI Artifact Spec designed specifically for use by applications which produce and consume WASM modules (as opposed to application containers). It is intended to provide a standard mechanism to manage the building and running of WASM modules. 
+
+This document considers primarily the use case of storing WASM Envoy Filters as OCI Images.
+
+### Terminology:
+
+| Term                               | Definition                                       |
+|------------------------------------|--------------------------------------------------|
+| WASM Module                        | The distributable, loadable, and executable unit of code in WebAssembly. 
+| WASM OCI Image Specification       | The specification for storing WASM modules as OCI Images.
+| WASM Runtime                       | The execution environment into which a WASM Module may be loaded. This refers to the application itself which loads and executes a wasm module. Examples include web browsers, the Open Policy Agent, the Envoy Proxy, or any other application which supports extension via WASM modules. 
+| Runtime Configuration              | Configuration specific to the runtime which consumes a module. This configuration is stored as JSON and bundled with the module in the image in the specification. 
+| Envoy WASM Filter                  | Custom Filters for the Envoy Proxy built as a WASM module.
+| Envoy WASM OCI Image               | Envoy Filters stored as OCI images according to the specification. 
+| Envoy WASM OCI Artifact Specification | An extension of the WASM OCI Artifact Spec which describes how to bundle and ship Envoy WASM filters as OCI Images. |
+
+### Description:
+
+#### Overview:
+
+The WASM OCI Artifact Specification defines a method of storing WASM modules which makes them easy to build, pull, publish, and execute.
+
+Because each execution environment (runtime) for a WASM module may have runtime-specific configuration parameters, a WASM image is composed of both a content layer, for the WASM module itself, as well as a config layer, with metadata describing the module which is relevant to the target runtime.
+
+#### Layers:
+
+The content layer always consists of the WASM module binary. 
+
+The config layer consists of a JSON-formatted string, which contains metadata for the target runtime. The runtime and ABI (Application Binary Interface) versions of an image can be deduced by parsing the config layer. 
+
+The config layer may also contain additional data, depending on the target runtime. For example, the config for a WASM Envoy Filter contains root_ids available on the filter. 
+
+For the sake of simplicity, the specification only supports a single module per image.
+
+#### Running OCI Images with Envoy:
+
+Envoy supports loading and running WASM modules via a file on local disk or an “Http datasource”.
+
+Envoy WASM Filters can be stored according to the spec and run with Istio and Gloo, with the help of a local cache which pulls images from remote registries.  
+
+Control planes then configure the Envoy instances to load the filter via the local cache, using the required root_id parameter supplied in the image config if it is available.
+
+
+### Format:
+
+The WASM OCI Artifact Spec consists of two layers bundled together:
+- A layer specifying configuration for the target runtime
+- A layer containing the compiled WASM module itself
+
+Each layer is associated with its own Media Type, which is stored in the OCI Descriptor for that layer:
+
+| Media Type | Type | Description |
+|------------|------|-------------|
+| application/vnd.module.wasm.config.v1+json | JSON Object | Configuration for the Target WASM runtime.
+| application/vnd.module.wasm.content.layer.v1+wasm | binary data (byte array) | The compiled module data |
+
+`application/vnd.module.wasm.config.v1+json` Property Descriptions:
+
+| Property   | Type | Description |
+|------------|------|-------------|
+| type | string | Name of the target runtime. Required. Specifies the intended runtime of the bundled module. The content of the Opaque JSON Config is specific to the type of WASM runtime. 
+| abiVersions | string array | List of ABI Versions for the target runtime with which the image is compatible. The format for the version is dependent upon the runtime itself.
+| config | JSON Object | This field stores any configuration parameters required by the target runtime. Its structure depends on the specified runtime. |
+
+
+### Envoy WASM Filter Specification
+
+The runtime config for Envoy WASM Filter OCI Images has the following format:
+
+- *type* is set to `envoy_proxy`
+- *abiVersion* is set to a recognized version of the Envoy Proxy WASM Filter ABI 
+- *config* is a JSON Object containing a list of Filter root_ids that can be used with the provided filter
+
+The `root_ids` key in the *config* JSON Object will have a list of strings as a value. Each string in the list corresponds to the name of a registered Root Context Helper defined in the module.
+
+#### Example:
+
+The following descriptors provide an example of the OCI Image descriptors for an Envoy WASM Filter stored according to the specification:
+```
+[
+  {
+    "mediaType": "application/vnd.module.wasm.config.v1+json",
+    "digest": "sha256:d0a165298ae270c5644be8e9938036a3a7a5191f6be03286c40874d761c18abf",
+    "size": 125,
+    "annotations": {
+      "org.opencontainers.image.title": "runtime-config.json"
+    }
+  },
+  {
+    "mediaType": "application/vnd.module.wasm.content.layer.v1+wasm",
+    "digest": "sha256:5e82b945b59d03620fb360193753cbd08955e30a658dc51735a0fcbc2163d41c",
+    "size": 1043056,
+    "annotations": {
+      "org.opencontainers.image.title": "filter.wasm"
+    }
+  }
+]
+```
+
+The following is the runtime config stored as the `application/vnd.module.wasm.config.v1+json` layer:
+
+```{
+  "type": "envoy_proxy",
+  "abi_version": "v0-541b2c1155fffb15ccde92b8324f3e38f7339ba6",
+  "config": {
+    "root_ids": [
+      "add_header_root_id"
+    ]
+  }
+}
+```
+
+You can use the `wasme` tool to take new or existing module code and package it according to the WASM OCI Spec.


### PR DESCRIPTION
**Description**

Following the discussion (led by @dgn) in the Istio Wasm-SIG, this PR added a variant of Wasm image spec for storing Wasm binaries as standard container images. 

Notably this new spec leverages the existing standard layers with either one of
- `application/vnd.oci.image.layer.v1.tar+gzip` or 
- `application/vnd.docker.image.rootfs.diff.tar.gzip`

media type, not based on the OCI Artifact Spec. This allows users to use standard CLI tools in container ecosystem (such as `docker`, `podman`, `buildah`, etc.) and push to any standard registries without requiring support for arbitrary mediaType (including the one used before).

See #208 and [a meeting note by @dgn](https://docs.google.com/document/d/1Uf-3RPFRyNl6ExYUeZERlB9Y8kyxZFaB6NbDZyguXwI/edit) for the background, and appendix sections here for how end-users would operate to build images.


cc @dgn, @yuval-k @PiotrSikora @bianpengyuan @kyessenov 

Signed-off-by: Takeshi Yoneda <takeshi@tetrate.io>

resolves #208

