### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -57,6 +57,7 @@ jobs:
     - uses: engineerd/setup-kind@v0.5.0
       with:
         skipClusterCreation: "true"
+        version: v0.11.1
     - name: Install Protoc
       uses: solo-io/setup-protoc@master
       with:
@@ -132,6 +133,7 @@ jobs:
     - uses: engineerd/setup-kind@v0.5.0
       with:
         skipClusterCreation: "true"
+        version: v0.11.1
     - name: Install Protoc
       uses: solo-io/setup-protoc@master
       with:

--- a/tools/wasme/changelog/v0.0.34/pin-kind-version.yaml
+++ b/tools/wasme/changelog/v0.0.34/pin-kind-version.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: pin kind version in CI/CD


### PR DESCRIPTION
Pin KinD, newer versions run newer versions of k8s which is unsupported by older versions of Istio (due to CRD v1beta1 API being deprecated in favor of v1 API). This was causing PRs on master using the latest version of KinD to fail.