### PR TITLE
Add github action to add new issues to project board

### DIFF
--- a/.github/workflows/issue_board.yaml
+++ b/.github/workflows/issue_board.yaml
@@ -1,0 +1,15 @@
+name: issue_board
+
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  add-to-project:
+    name: Add WASM issue to Gloo Edge project board
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/solo-io/projects/22
+          github-token: ${{ github.token }}

--- a/.github/workflows/issue_board.yaml
+++ b/.github/workflows/issue_board.yaml
@@ -4,6 +4,7 @@ on:
   issues:
     types:
       - opened
+      - labeled
 jobs:
   add-to-project:
     name: Add WASM issue to Gloo Edge project board
@@ -13,3 +14,8 @@ jobs:
         with:
           project-url: https://github.com/orgs/solo-io/projects/22
           github-token: ${{ github.token }}
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/solo-io/projects/15
+          github-token: ${{ github.token }}
+          labeled: "Type: Docs"

--- a/.github/workflows/issue_board.yaml
+++ b/.github/workflows/issue_board.yaml
@@ -18,6 +18,6 @@ jobs:
           label-operator: OR
       - uses: actions/add-to-project@main
         with:
-          project-url: https://github.com/orgs/solo-io/projects/15
+          project-url: https://github.com/orgs/solo-io/projects/24
           github-token: ${{ github.token }}
           labeled: documentation

--- a/.github/workflows/issue_board.yaml
+++ b/.github/workflows/issue_board.yaml
@@ -14,8 +14,10 @@ jobs:
         with:
           project-url: https://github.com/orgs/solo-io/projects/22
           github-token: ${{ github.token }}
+          labeled: enhancement, bug
+          label-operator: OR
       - uses: actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/solo-io/projects/15
           github-token: ${{ github.token }}
-          labeled: "Type: Docs"
+          labeled: documentation

--- a/tools/wasme/changelog/v0.0.35/issue-automation.yaml
+++ b/tools/wasme/changelog/v0.0.35/issue-automation.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Add a github workflow to automatically add new issues to the project board.


### PR DESCRIPTION
# Description

First PR for this: https://github.com/solo-io/gloo/issues/6305
It's hard to manually test github actions so my plan is to manually verify in this repo before implementing in the other repos. 
