### PR TITLE
Update secret for GHA

### DIFF
--- a/.github/workflows/issue_board.yaml
+++ b/.github/workflows/issue_board.yaml
@@ -19,5 +19,5 @@ jobs:
       - uses: actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/solo-io/projects/24
-          github-token: ${{ github.token }}
+          github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           labeled: documentation

--- a/tools/wasme/changelog/v0.0.35/gha_secret.yaml
+++ b/tools/wasme/changelog/v0.0.35/gha_secret.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Use a different token (secrets.PERSONAL_ACCESS_TOKEN) when adding issues to team boards.


### PR DESCRIPTION
# Description
The secret I used in the last iteration does not have permissions to edit issues/update team boards. 

# Context
Previous PR: https://github.com/solo-io/wasm/pull/287
