### PR TITLE
Use the newly created token for the GHA to add issues to boards

### DIFF
--- a/.github/workflows/issue_board.yaml
+++ b/.github/workflows/issue_board.yaml
@@ -13,11 +13,11 @@ jobs:
       - uses: actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/solo-io/projects/22
-          github-token: ${{ github.token }}
+          github-token: ${{ secrets.ORG_CROSS_REPO }}
           labeled: enhancement, bug
           label-operator: OR
       - uses: actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/solo-io/projects/24
-          github-token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          github-token: ${{ secrets.ORG_CROSS_REPO }}
           labeled: documentation

--- a/tools/wasme/changelog/v0.0.35/gha_secret.yaml
+++ b/tools/wasme/changelog/v0.0.35/gha_secret.yaml
@@ -1,3 +1,0 @@
-changelog:
-  - type: NON_USER_FACING
-    description: Use a different token (secrets.PERSONAL_ACCESS_TOKEN) when adding issues to team boards.

--- a/tools/wasme/changelog/v0.0.35/new-token.yaml
+++ b/tools/wasme/changelog/v0.0.35/new-token.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Created a token specifically with the permissions required by the action used to add issues to boards.


### PR DESCRIPTION
# Description
The existing personal access token couldn't read the team boards. 

